### PR TITLE
Address issue with PATCH payload and complex attributes in extension schemas

### DIFF
--- a/app/models/scimitar/resources/mixin.rb
+++ b/app/models/scimitar/resources/mixin.rb
@@ -990,8 +990,12 @@ module Scimitar
             end
 
             found_data_for_recursion.each do | found_data |
+              extension_schema = self.class.scim_resource_type&.schemas&.detect { |schema| schema.id == path_component }
+
               attr_map = if path_component.to_sym == :root
                 with_attr_map
+              elsif extension_schema
+                with_attr_map.slice(*extension_schema.scim_attributes.map { |attr| attr.name.to_sym })
               else
                 with_attr_map[path_component.to_sym]
               end


### PR DESCRIPTION
Address the case when sub attributes of the complex attribute belonging to the extension schema could not be assigned properly when processing SCIM PATCH request.

I don't want to add this repo to our CI/CD pipeline, so here is a spec run artefact:
<img width="1222" height="321" alt="scimitar" src="https://github.com/user-attachments/assets/017b4a12-f5b9-49e9-a9bb-c209e067c0df" />

